### PR TITLE
feat(sdk): @nousviz/client 1.1.0 — annotation matching helpers

### DIFF
--- a/.github/workflows/publish-sdk-npm.yml
+++ b/.github/workflows/publish-sdk-npm.yml
@@ -1,0 +1,47 @@
+name: Publish SDK to npm
+
+# Manual-trigger workflow for publishing @nousviz/client to npm
+# independently of the app-wide tag-driven release pipeline.
+#
+# Use this when the JS SDK has new exports but the app version isn't
+# changing — avoids bumping VERSION/PyPI just to ship an SDK update.
+#
+# Required secret:
+#   NPM_TOKEN — npm publish token for @nousviz/client
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Build only, skip npm publish"
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    name: Build + publish @nousviz/client
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Show package version
+        working-directory: packages/client-ts
+        run: node -p "require('./package.json').version"
+
+      - name: Install + build
+        working-directory: packages/client-ts
+        run: |
+          npm ci
+          npm run build
+
+      - name: Publish to npm
+        if: ${{ inputs.dry_run == false }}
+        working-directory: packages/client-ts
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/packages/client-ts/package.json
+++ b/packages/client-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nousviz/client",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Auto-generated TypeScript client for the NousViz API.",
   "license": "MIT",
   "type": "module",

--- a/packages/client-ts/src/chart-annotations.ts
+++ b/packages/client-ts/src/chart-annotations.ts
@@ -1,0 +1,112 @@
+/**
+ * Helpers for matching NousViz annotations against a chart's x-axis values.
+ *
+ * Use these in a custom plugin widget that receives `annotations` from the
+ * host DashboardRenderer:
+ *
+ *   import { annotationsForXValue, type AnnotationLike } from "@nousviz/client";
+ *
+ *   function MyChart({ annotations = [], data }) {
+ *     const matches = (rawX) => annotationsForXValue(annotations, rawX);
+ *     // render whatever marker you like at each row whose x matches.
+ *   }
+ *
+ * The host pre-filters annotations by plugin_id, so the array you receive
+ * already excludes other plugins' notes. You typically don't need to
+ * filter further unless you also want to scope by `dataset`.
+ */
+
+// Minimal shape required by the matcher. Re-stated here so plugin authors
+// don't need to import the full `AnnotationRow` type — they can hand in
+// any object that quacks like an annotation, including the host-supplied
+// AnnotationRow (which is intentionally `Record<string, any>`).
+export interface AnnotationLike {
+  date_start: string;       // ISO date "YYYY-MM-DD"
+  date_end?: string | null; // optional inclusive end; null/undefined = point annotation
+  severity?: string | null;
+  color?: string | null;
+}
+
+/**
+ * Convert a chart's raw x-axis value into the date range it represents.
+ * Supported formats:
+ *   - "YYYY-MM-DD"  → that single day
+ *   - "YYYY-Www"    → Monday..Sunday of that ISO 8601 week
+ *   - "YYYY-MM"     → first..last day of that month
+ *
+ * Anything else returns null — caller treats it as a categorical x value
+ * (e.g. project name on a bar chart) with no date matching possible.
+ */
+export function xValueToDateRange(raw: unknown): { start: Date; end: Date } | null {
+  if (typeof raw !== "string") return null;
+
+  let m = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (m) {
+    const d = new Date(Date.UTC(+m[1], +m[2] - 1, +m[3]));
+    return { start: d, end: d };
+  }
+
+  m = raw.match(/^(\d{4})-W(\d{2})$/);
+  if (m) {
+    const monday = isoWeekToMonday(+m[1], +m[2]);
+    const sunday = new Date(monday);
+    sunday.setUTCDate(monday.getUTCDate() + 6);
+    return { start: monday, end: sunday };
+  }
+
+  m = raw.match(/^(\d{4})-(\d{2})$/);
+  if (m) {
+    const first = new Date(Date.UTC(+m[1], +m[2] - 1, 1));
+    const last = new Date(Date.UTC(+m[1], +m[2], 0));
+    return { start: first, end: last };
+  }
+
+  return null;
+}
+
+// ISO 8601: week 1 contains the year's first Thursday.
+function isoWeekToMonday(year: number, week: number): Date {
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Day = jan4.getUTCDay() || 7;
+  const week1Monday = new Date(jan4);
+  week1Monday.setUTCDate(jan4.getUTCDate() - jan4Day + 1);
+  const result = new Date(week1Monday);
+  result.setUTCDate(week1Monday.getUTCDate() + (week - 1) * 7);
+  return result;
+}
+
+function annotationDateRange(a: AnnotationLike): { start: Date; end: Date } {
+  const start = new Date(`${a.date_start}T00:00:00Z`);
+  const end = a.date_end ? new Date(`${a.date_end}T00:00:00Z`) : start;
+  return { start, end };
+}
+
+function rangesOverlap(a: { start: Date; end: Date }, b: { start: Date; end: Date }): boolean {
+  return a.start.getTime() <= b.end.getTime() && b.start.getTime() <= a.end.getTime();
+}
+
+/**
+ * Return the subset of `annotations` whose date range overlaps the bucket
+ * that `rawX` represents. Empty array if rawX isn't a recognised date format.
+ */
+export function annotationsForXValue<T extends AnnotationLike>(annotations: T[], rawX: unknown): T[] {
+  const bucket = xValueToDateRange(rawX);
+  if (!bucket) return [];
+  return annotations.filter((a) => rangesOverlap(bucket, annotationDateRange(a)));
+}
+
+/**
+ * Suggested stroke color for an annotation marker, driven by severity.
+ * Plugin authors are free to roll their own — this is just a sensible default.
+ */
+export function annotationStrokeColor(a: AnnotationLike): string {
+  if (a.color) return a.color;
+  switch (a.severity) {
+    case "critical":
+      return "#ef4444";
+    case "warning":
+      return "#f59e0b";
+    default:
+      return "#fbbf24";
+  }
+}

--- a/packages/client-ts/src/index.ts
+++ b/packages/client-ts/src/index.ts
@@ -13,6 +13,16 @@ import type { OpenAPIConfig } from "./generated";
 // Re-export every model + service.
 export * from "./generated";
 
+// Hand-written helpers (not OpenAPI-generated). Plugin authors building
+// custom widgets get annotation matching here without re-implementing
+// ISO-week math.
+export {
+  annotationsForXValue,
+  xValueToDateRange,
+  annotationStrokeColor,
+  type AnnotationLike,
+} from "./chart-annotations";
+
 /**
  * Configure the shared client.
  *


### PR DESCRIPTION
## Summary
- Adds `annotationsForXValue`, `xValueToDateRange`, `annotationStrokeColor` + `AnnotationLike` exports to `@nousviz/client` so plugin authors building custom chart widgets can match annotations to x-axis values (YYYY-MM-DD / YYYY-Www / YYYY-MM) without re-implementing ISO-week math.
- Bumps SDK package to 1.1.0 (does not touch app VERSION or PyPI packages).
- Adds a manual-trigger workflow (`publish-sdk-npm.yml`) so the SDK can be published independently of the tag-driven app release pipeline.

## Context
Pairs with the chart-annotations feature already deployed to nousviz.online — built-in chart widgets render markers automatically, and custom plugin widgets receive an `annotations` prop. This PR ships the helpers external plugin authors need to consume that prop.

## Test plan
- [ ] After merge: `gh workflow run publish-sdk-npm.yml -R nousviz/nousviz-app` triggers the manual workflow
- [ ] Workflow builds and publishes @nousviz/client@1.1.0 to npm (uses existing NPM_TOKEN secret)
- [ ] `npm view @nousviz/client@1.1.0` confirms publish landed
- [ ] Optional dry run first: trigger with `dry_run: true` to verify build without publishing